### PR TITLE
fix: prevent BUTRInputManager orphan crash on game v1.4.4+

### DIFF
--- a/src/Bannerlord.LauncherEx/Patches/LauncherUIPatch.cs
+++ b/src/Bannerlord.LauncherEx/Patches/LauncherUIPatch.cs
@@ -1,4 +1,4 @@
-﻿using Bannerlord.LauncherEx.Helpers;
+using Bannerlord.LauncherEx.Helpers;
 
 using HarmonyLib;
 using HarmonyLib.BUTR.Extensions;
@@ -23,15 +23,19 @@ internal static class LauncherUIPatch
             postfix: AccessTools2.DeclaredMethod(typeof(LauncherUIPatch), nameof(InitializePostfix)));
         if (!res1) return false;
 
-        var res2 = harmony.TryPatch(
-            AccessTools2.DeclaredMethod(typeof(LauncherUI), "Update"),
-            postfix: AccessTools2.DeclaredMethod(typeof(LauncherUIPatch), nameof(UpdatePostfix)));
-        if (!res2) return false;
-
+        // Patch the cleanup point before installing BUTRInputManager.
+        // If LauncherUI.AdditionalArgs was removed or renamed in this game version,
+        // installing BUTRInputManager without a cleanup path would leave it active
+        // when the game starts, causing a native crash (e.g. at GauntletVideoPlaybackScreen).
         var res3 = harmony.TryPatch(
             AccessTools2.DeclaredPropertyGetter(typeof(LauncherUI), "AdditionalArgs"),
             postfix: AccessTools2.DeclaredMethod(typeof(LauncherUIPatch), nameof(AdditionalArgsPostfix)));
         if (!res3) return false;
+
+        var res2 = harmony.TryPatch(
+            AccessTools2.DeclaredMethod(typeof(LauncherUI), "Update"),
+            postfix: AccessTools2.DeclaredMethod(typeof(LauncherUIPatch), nameof(UpdatePostfix)));
+        if (!res2) return false;
 
         return true;
     }


### PR DESCRIPTION
## Problem

When BLSE v1.6.5 runs on game **v1.4.4** (build 114449), it falls back to the `v1.4.0` LauncherEx binary (the highest compiled version below 1.4.4, selected by `ModuleInitializer.ResolveLauncherExAssemblies`).

In that binary, `LauncherUIPatch.Enable()` applies patches in this order:
1. `LauncherUI.Initialize` → **succeeds** (res1 = true)
2. `LauncherUI.Update` → **succeeds** (res2 = true) — installs `BUTRInputManager`
3. `LauncherUI.AdditionalArgs` → **fails** (res3 = false) — `AdditionalArgs` was removed or renamed in v1.4.4

`Enable()` returns `false` after step 3, but `Manager.Enable()` ignores the return value. The result: `BUTRInputManager` is installed by the `Update` postfix, but the `AdditionalArgs` postfix (which restores the original input manager) never fires.

When the user clicks Play and the game starts in the same process, the native engine initializes its input subsystem and immediately crashes inside `GauntletVideoPlaybackScreen::HandleResume` because `BUTRInputManager` is still the active `Input.InputManager`.

Observed crash point from `rgl_log_*.txt`:
```
TaleWorlds.MountAndBlade.GauntletUI.GauntletVideoPlaybackScreen::HandleInitialize
TaleWorlds.MountAndBlade.GauntletUI.GauntletVideoPlaybackScreen::HandleActivate
TaleWorlds.MountAndBlade.GauntletUI.GauntletVideoPlaybackScreen::HandleResume
[crash — no further output]
```

Confirmed via `watchdog_log_*.txt`: game version is **v1.4.4 build 114449**, GPU AMD Radeon RX 9070 XT. Vanilla (no BLSE) and BLSE with only base modules both work correctly.

## Fix

Reorder the patch calls in `LauncherUIPatch.Enable()` so that `AdditionalArgs` (the cleanup) is patched **before** `Update` (the install). If `AdditionalArgs` is not found in the current game version, `Enable()` returns `false` before `BUTRInputManager` is ever installed. The game then starts with its original input manager intact.

The `Initialize` postfix (launcher UI setup) is still applied regardless — it does not interact with the input manager.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| Game version with `AdditionalArgs` (e.g. v1.4.0, v1.3.x) | Full input enhancement | Unchanged |
| Game version **without** `AdditionalArgs` (e.g. v1.4.4) | Crash on game start | Launcher keyboard input silently disabled; game starts cleanly |

## Long-term note

The correct long-term fix is to add a `GameAPIVersion` entry for v1.4.2+ in `Bannerlord.BLSE.Shared.csproj` once `Bannerlord.ReferenceAssemblies.Core` v1.4.4 is published, so a properly targeted LauncherEx binary exists for v1.4.4. This PR is the defensive fallback that prevents the crash in the meantime.